### PR TITLE
Fix rmi4utils Android build.

### DIFF
--- a/Application.mk
+++ b/Application.mk
@@ -1,4 +1,4 @@
 APP_BUILD_SCRIPT := $(call my-dir)/Android.mk
-APP_STL := stlport_static
+APP_STL := c++_static
 APP_PLATFORM := android-21
-APP_ABI := armeabi armeabi-v7a arm64-v8a
+APP_ABI := armeabi-v7a arm64-v8a

--- a/README
+++ b/README
@@ -5,7 +5,6 @@ Build for Android:
 This tool depends on HIDRAW being compiled into the Android device's kernel. This may not be enabled by default. When developing on platforms you may need to rebuild the kernel to enable it.
 
 Then:
-Install the latest verison of the Android NDK.
-Copy from the kernel source include/linux/hid.h and include/linux/hidraw.h to $(ANDROID_NDK)/platforms/android-19/arch-arm/usr/include/linux/
+Install the latest version of the Android NDK, and add it to your PATH.
 Then run:
 $ make android

--- a/rmidevice/hiddevice.cpp
+++ b/rmidevice/hiddevice.cpp
@@ -661,7 +661,12 @@ bool HIDDevice::CheckABSEvent()
 	unsigned long bit[EV_MAX][NBITS(KEY_MAX)];
 
 
+#ifdef __BIONIC__
+	// Android's libc doesn't have the GNU versionsort extension.
+	ndev = scandir(DEV_INPUT_EVENT, &namelist, is_event_device, alphasort);
+#else
 	ndev = scandir(DEV_INPUT_EVENT, &namelist, is_event_device, versionsort);
+#endif
 	if (ndev <= 0)
 		return false;
 	for (i = 0; i < ndev; i++)


### PR DESCRIPTION
I hit the versionsort issue trying to update the AOSP copy of rmi4utils. The other issues I hit when trying to build ToT with the current NDK (r21).