### PR TITLE
Parsing driver name instead of assigning one

### DIFF
--- a/rmidevice/hiddevice.cpp
+++ b/rmidevice/hiddevice.cpp
@@ -851,15 +851,8 @@ bool HIDDevice::FindTransportDevice(uint32_t bus, std::string & hidDeviceName,
 
 	if (bus == BUS_I2C) {
 		devicePrefix += "i2c/";
-		// From new patch released on 2020/11, i2c_hid would be renamed as i2c_hid_acpi,
-		// and also need backward compatible.
-		std::string driverPathTemp = devicePrefix + "drivers/i2c_hid/";
-		DIR *driverPathtest = opendir(driverPathTemp.c_str());
-		if(!driverPathtest) {
-			driverPath = devicePrefix + "drivers/i2c_hid_acpi/";
-		} else {
-			driverPath = devicePrefix + "drivers/i2c_hid/";
-		}
+		// The i2c driver module installed on system is vary (i2c_hid, i2c_hid_acpi, i2c_hid_of),
+		// so we will assign driver path until we get device name later.
 	} else {
 		devicePrefix += "usb/";
 		driverPath = devicePrefix + "drivers/usbhid/";
@@ -898,8 +891,25 @@ bool HIDDevice::FindTransportDevice(uint32_t bus, std::string & hidDeviceName,
 		}
 		closedir(devDir);
 
-		if (deviceFound)
+		if (deviceFound) {
+			if (bus == BUS_I2C) {
+				std::fstream ueventfile;
+				std::string ueventfilepath = fullLinkPath + "/uevent";
+				std::string uevent;
+				std::string modulename;
+				ueventfile.open(ueventfilepath.c_str(), std::ios::in);
+				if(ueventfile.is_open()) {
+					getline(ueventfile, uevent);
+					modulename = uevent.substr(uevent.find("=") + 1, std::string::npos);
+					driverPath = devicePrefix + "drivers/";
+					driverPath += modulename;
+					driverPath += "/";
+				}
+				ueventfile.close();
+			}
 			break;
+		}
+			
 	}
 	closedir(devicesDir);
 

--- a/rmidevice/hiddevice.h
+++ b/rmidevice/hiddevice.h
@@ -20,6 +20,7 @@
 
 #include <linux/hidraw.h>
 #include <string>
+#include <fstream>
 #include <stdint.h>
 #include "rmidevice.h"
 


### PR DESCRIPTION
HDR-42153
We've found the driver mounted on device would be i2c_hid_of, not expected i2c_hid or i2c_hid_acpi
In step of rebind driver, we write the device name to the file with non-existed driver module name like i2c_hid_acpi.
Instead of assigning one in hard-coded way, we get the driver path by parsing uevent of device.