### PR TITLE
Support debugging message in read/write

### DIFF
--- a/rmi4update/main.cpp
+++ b/rmi4update/main.cpp
@@ -36,7 +36,9 @@
 #define VERSION_MINOR		3
 #define VERSION_SUBMINOR	9
 
-#define RMI4UPDATE_GETOPTS	"hfd:t:pclv"
+#define RMI4UPDATE_GETOPTS	"hfd:t:pclvm"
+
+bool needDebugMessage; 
 
 void printHelp(const char *prog_name)
 {
@@ -66,6 +68,9 @@ int GetFirmwareProps(const char * deviceFile, std::string &props, bool configid)
 	rc = rmidevice.Open(deviceFile);
 	if (rc)
 		return rc;
+	
+	if (needDebugMessage)
+		rmidevice.m_hasDebug = true;
 
 	// Clear all interrupts before parsing to avoid unexpected interrupts.
 	rmidevice.ToggleInterruptMask(false);
@@ -115,6 +120,7 @@ int main(int argc, char **argv)
 	bool printFirmwareProps = false;
 	bool printConfigid = false;
 	bool performLockdown = false;
+	needDebugMessage = false;
 	HIDDevice device;
 	enum RMIDeviceType deviceType = RMI_DEVICE_TYPE_ANY;
 
@@ -148,6 +154,9 @@ int main(int argc, char **argv)
 			case 'v':
 				printVersion();
 				return 0;
+			case 'm':
+				needDebugMessage = true;
+				break;
 			default:
 				break;
 
@@ -195,6 +204,9 @@ int main(int argc, char **argv)
 			return 1;
 	}
 
+	if (needDebugMessage) {
+		device.m_hasDebug = true;
+	}
 
 	RMI4Update update(device, image);
 	rc = update.UpdateFirmware(force, performLockdown);

--- a/rmidevice/hiddevice.cpp
+++ b/rmidevice/hiddevice.cpp
@@ -306,6 +306,10 @@ int HIDDevice::Read(unsigned short addr, unsigned char *buf, unsigned short len)
 	if (!m_deviceOpen)
 		return -1;
 
+	if (m_hasDebug) {
+		fprintf(stdout, "R %02x : ", addr);
+	}
+
 	if (m_bytesPerReadRequest)
 		bytesPerRequest = m_bytesPerReadRequest;
 	else
@@ -386,6 +390,12 @@ Resend:
 		}
 		addr += bytesPerRequest;
 	}
+	if (m_hasDebug) {
+		for (int i=0 ; i<len ; i++) {
+			fprintf(stdout, "%02x ", buf[i]);
+		}
+		fprintf(stdout, "\n");
+	}
 
 	return totalBytesRead;
 }
@@ -405,6 +415,14 @@ int HIDDevice::Write(unsigned short addr, const unsigned char *buf, unsigned sho
 	m_outputReport[HID_RMI4_WRITE_OUTPUT_ADDR] = addr & 0xFF;
 	m_outputReport[HID_RMI4_WRITE_OUTPUT_ADDR + 1] = (addr >> 8) & 0xFF;
 	memcpy(&m_outputReport[HID_RMI4_WRITE_OUTPUT_DATA], buf, len);
+
+	if (m_hasDebug) {
+		fprintf(stdout, "W %02x : ", addr);
+		for (int i=0 ; i<len ; i++) {
+			fprintf(stdout, "%02x ", buf[i]);
+		}
+		fprintf(stdout, "\n");
+	}
 
 	for (;;) {
 		m_bCancel = false;

--- a/rmidevice/rmidevice.h
+++ b/rmidevice/rmidevice.h
@@ -38,7 +38,7 @@ class RMIDevice
 public:
 	RMIDevice() : m_functionList(), m_sensorID(0), m_bCancel(false), m_bytesPerReadRequest(0), m_page(-1),
 		      m_deviceType(RMI_DEVICE_TYPE_ANY)
-	{}
+	{ m_hasDebug = false; }
 	virtual ~RMIDevice() {}
 	virtual int Open(const char * filename) = 0;
 	virtual int Read(unsigned short addr, unsigned char *data,
@@ -82,6 +82,8 @@ public:
 
 	virtual bool FindDevice(enum RMIDeviceType type = RMI_DEVICE_TYPE_ANY) = 0;
 	enum RMIDeviceType GetDeviceType() { return m_deviceType; }
+
+	bool m_hasDebug;
 
 protected:
 	std::vector<RMIFunction> m_functionList;


### PR DESCRIPTION
HDR-42161
It might have chance to see which read/write transaction is failed, so add debugging message for further analysis.